### PR TITLE
Enable video downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ setup:
 		--zip-file fileb://tmp/zips/augment_media.py.zip \
 		--handler augment_media.lambda_handler \
 		--role arn:aws:iam::000000000000:role/lambda-role \
-		--timeout 10 \
+		--timeout 30 \
 		--environment Variables="{bucket=$(BUCKET)}" \
 		--layers $(LAYER_ARN)
 

--- a/lambda/augment_media.py
+++ b/lambda/augment_media.py
@@ -27,7 +27,63 @@ def lambda_handler(event, context):
     }
 
 def save_media_entities(media_data, tweet_id):
+    print(media_data)
     for item in media_data:
-        data = requests.get(item["url"])
-        file_target = "liked_media/" + str(tweet_id) + "-" + item["url"].split("/")[-1]
-        S3.upload_fileobj(io.BytesIO(data.content), os.environ["bucket"], file_target)
+        if item["type"] == "photo":
+            save_photo(item["url"], tweet_id)
+        elif item["type"] == "video":
+            save_video(item["url"], tweet_id)
+
+def save_photo(photo_url, tweet_id):
+    data = requests.get(photo_url)
+    file_target = "liked_media/" + str(tweet_id) + "-" + photo_url.split("/")[-1]
+    S3.upload_fileobj(io.BytesIO(data.content), os.environ["bucket"], file_target)
+
+def save_video(video_url, tweet_id):
+    file_target = "liked_media/" + str(tweet_id) + "-" + video_url.split("/")[-1].split('?tag')[0]
+
+    print("file_target: " + file_target)
+    print("video_url: " + video_url)
+
+    multipart_upload = S3.create_multipart_upload(
+        Bucket=os.environ["bucket"],
+        ContentType="video/mp4",
+        Key=file_target
+    )
+    uploadID = multipart_upload['UploadId']
+
+    parts = []
+    part_number = 1
+
+    with requests.get(video_url) as datastream:
+        # Use the suggested default (minimum) size of 5MB - chunk_size is in bytes
+        for chunk in datastream.iter_content(chunk_size=1024 * 1024 * 5):
+            if chunk:
+                uploadPart = S3.upload_part(
+                    Body=chunk,
+                    Bucket=os.environ["bucket"],
+                    Key=file_target,
+                    PartNumber=part_number,
+                    UploadId=uploadID
+                )
+
+                parts.append({
+                    'PartNumber': part_number,
+                    'ETag': uploadPart['ETag']
+                })
+
+                part_number += 1
+                print("part_number is now:")
+                print(part_number)
+
+    print("done making parts")
+
+    completeResult = S3.complete_multipart_upload(
+        Bucket=os.environ["bucket"],
+        Key=file_target,
+        MultipartUpload={ 'Parts': parts },
+        UploadId=multipart_upload['UploadId']
+    )
+
+    print("and we're out!")
+    print(completeResult)

--- a/lambda/hydrate_tweet.py
+++ b/lambda/hydrate_tweet.py
@@ -27,7 +27,7 @@ def lambda_handler(event, context):
                                 expansions=["author_id", "entities.mentions.username", "attachments.media_keys"],
                                 tweet_fields=["created_at", "entities"],
                                 user_fields=["username", "verified", "protected", "description", "name"],
-                                media_fields=["alt_text", "url"])
+                                media_fields=["alt_text", "url", "variants"])
 
     tweet = response.data
 

--- a/lambda/hydrate_tweet.py
+++ b/lambda/hydrate_tweet.py
@@ -220,12 +220,37 @@ def url_entities(url_data):
 def media_entities(media_data):
     media = []
     for item in media_data:
-        media.append({
-            "alt_text": item["alt_text"],
-            "media_key": item["media_key"],
-            "type": item["type"],
-            "url": item["url"]
-        })
+        if "variants" in item.keys():
+            variants = item["variants"]
+
+            if len(variants) > 1:
+                filtered = [opt for opt in variants if opt['content_type'] == 'video/mp4']
+                video_url = filtered[0]['url']
+                for option in filtered:
+                    if option['url'].find("640"):
+                        video_url = option['url']
+                        break
+                    if option['url'].find("480"):
+                        video_url = option['url']
+                        break
+                else:
+                    video_url = variants[0]['url']
+            else:
+                video_url = variants[0]['url']
+
+            media.append({
+                "alt_text": item["alt_text"],
+                "media_key": item["media_key"],
+                "type": item["type"],
+                "url": video_url
+            })
+        else:
+            media.append({
+                "alt_text": item["alt_text"],
+                "media_key": item["media_key"],
+                "type": item["type"],
+                "url": item["url"]
+            })
     return media
 
 def get_secret():


### PR DESCRIPTION
Turns out, Twitter converts animated gifs to video format (mp4) and those are accessed in a different way. I only discovered this after I'd downloaded my archive data so I had to pull the data into Athena, ask it to find which data had video content and ran a horrible, local script to go get all of those then uploaded them all in my laptop.

This tells the augment_media Lambda to download videos as it finds them instead, which is much saner.

The code acts as though there are multiple videos - as there often are for photos - (or multiple media types) which does not appear to be true. But does no harm, and is actually useful as if there were multiple videos, the script would most likely time out.

Code changes:
* Get the variants data from Twitter as that's where the video data lives
* Make a terrible guess at which file is the most relevant (try to find a specific size, then give up and get the first mp4 file)
* Use `requests` to get the video file in 5MB chunks and S3 MultiUpload to add it to the bucket

Here be dragons - there's no error handling logic here so if it fails for real, it strands the MultipartUpload part files (which are hidden in the bucket, you'll have to use the aws cli to find and remove them) in the bucket. You will get charged for storing them. If it fails inside LocalStack, that's fine - they're inside the container so they'll be removed on shutdown. Use in the wild with caution!